### PR TITLE
test-fix

### DIFF
--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -214,7 +214,7 @@ describe('CodeBreaker :', () => {
       assert(code.className.indexOf(' success') != -1,'`code`\'s `className` did not have ` success` in it when parameter was `true`.');
       //test false
       code.value = '';
-      code.className = '';
+      code.className = 'code';
       window.showAnswer(false);
       assert(document.getElementById('answer').value == code.innerHTML, '`code`\'s `innerHTML` did not match the `answer`\'s value when parameter was `false`.');
       assert(code.className.indexOf(' failure') != -1,'`code`\'s `className` did not have ` failure` in it when parameter was `false`.');


### PR DESCRIPTION
The original test empties the class list of the code element it is testing, then checks for the ' failure' string.
This gives a false negative result if the coder creates their solution using jQuery, as jQuery does not add the space unless there is another class already present.

With this fix, both vanilla and jQuery solutions would be tested correctly.